### PR TITLE
Modified derive_unit to return expression units without scale_factor.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ env:
 before_install:
   - travis_retry pip install twine wheel coveralls
   - travis_retry pip install check-manifest pydocstyle
-  - travis_retry pip install https://github.com/sympy/sympy/archive/1.1.zip
+  - travis_retry pip install https://github.com/sympy/sympy/zipball/master
 
 install:
   - pip install -e .[all]

--- a/essm/variables/units.py
+++ b/essm/variables/units.py
@@ -34,7 +34,8 @@ mole = u.mole
 pascal = u.pascal
 second = u.second
 watt = u.watt
-BASEUNITS = set(str(unit) for unit in SI._base_units)
+
+SI_DIMENSIONS = {str(d._dimension.name): d for d in SI._base_units}
 
 
 def markdown(unit):
@@ -59,25 +60,11 @@ def derive_quantity(expr, name=None):
 
 def derive_unit(expr, name=None):
     """Derive SI-unit from an expression, omitting scale factors."""
-    # Get dimensions of expr
-    dim_expr = Quantity.get_dimensional_expr(expr)
-
-    # Generate dictionary with standard units to substitute into dim_expr
-    units = {}
-    for dim in dim_expr.free_symbols:
-        dimension1 = Dimension(dim)
-
-        # Get base dimensions (e.g. length**3 instead of volume)
-        dimensional_dependencies = dimension1.get_dimensional_dependencies()
-
-        # Generate dictionary with standard units of each base dimension
-        units1 = []
-        for dim1 in dimensional_dependencies.keys():
-            unit = list(set(find_unit(dim1)) & (BASEUNITS))[0]
-            units1.append(getattr(u, unit) ** dimensional_dependencies[dim1])
-        units_dim = functools.reduce(operator.mul, units1)
-        units[dim] = units_dim
-    return dim_expr.xreplace(units)
+    dim = Dimension(Quantity.get_dimensional_expr(expr))
+    return functools.reduce(
+        operator.mul, (
+            SI_DIMENSIONS[d] ** p
+            for d, p in Dimension.get_dimensional_dependencies(dim).items()))
 
 
 __all__ = (

--- a/essm/variables/units.py
+++ b/essm/variables/units.py
@@ -21,8 +21,9 @@
 
 import functools
 import operator
+
 import sympy.physics.units as u
-from sympy.physics.units import find_unit, Dimension, Quantity
+from sympy.physics.units import Dimension, Quantity, find_unit
 
 from .SI import SI
 

--- a/essm/variables/units.py
+++ b/essm/variables/units.py
@@ -62,12 +62,11 @@ def derive_quantity(expr, name=None):
 def derive_unit(expr, name=None):
     """Derive SI-unit from an expression, omitting scale factors."""
     dim = Dimension(Quantity.get_dimensional_expr(expr))
-    if dim == Dimension(1):
-        return 1
     return functools.reduce(
         operator.mul, (
             SI_DIMENSIONS[d] ** p
-            for d, p in Dimension.get_dimensional_dependencies(dim).items()))
+            for d, p in Dimension.get_dimensional_dependencies(dim).items()),
+        1)
 
 
 __all__ = (

--- a/essm/variables/units.py
+++ b/essm/variables/units.py
@@ -62,6 +62,8 @@ def derive_quantity(expr, name=None):
 def derive_unit(expr, name=None):
     """Derive SI-unit from an expression, omitting scale factors."""
     dim = Dimension(Quantity.get_dimensional_expr(expr))
+    if dim == Dimension(1):
+        return 1
     return functools.reduce(
         operator.mul, (
             SI_DIMENSIONS[d] ** p

--- a/essm/variables/units.py
+++ b/essm/variables/units.py
@@ -74,7 +74,7 @@ def derive_unit(expr, name=None):
         units1 = []
         for dim1 in dimensional_dependencies.keys():
             unit = list(set(find_unit(dim1)) & (BASEUNITS))[0]
-            units1.append(eval('u.' + unit) ** dimensional_dependencies[dim1])
+            units1.append(getattr(u, unit) ** dimensional_dependencies[dim1])
         units_dim = functools.reduce(operator.mul, units1)
         units[dim] = units_dim
     return dim_expr.xreplace(units)

--- a/essm/variables/units.py
+++ b/essm/variables/units.py
@@ -77,7 +77,7 @@ def derive_unit(expr, name=None):
             units1.append(eval('u.' + unit) ** dimensional_dependencies[dim1])
         units_dim = functools.reduce(operator.mul, units1)
         units[dim] = units_dim
-    return dim_expr.subs(units)
+    return dim_expr.xreplace(units)
 
 
 __all__ = (

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -70,6 +70,7 @@ def test_derive_unit():
 
     assert derive_unit(2 * lambda_E * E_l) \
         == kilogram * meter ** 2 / second ** 5
+    assert derive_unit(E_l/E_l) == 1
 
 
 def test_remove_variable_from_registry():

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -4,7 +4,7 @@
 import pytest
 
 from essm.variables import Variable
-from essm.variables.units import meter, second
+from essm.variables.units import derive_unit, joule, kilogram, meter, second
 
 
 class demo_variable(Variable):
@@ -58,6 +58,18 @@ def test_unit_check():
         class invalid_unit(Variable):
             expr = 4 * demo_variable
             unit = second
+
+
+def test_derive_unit():
+    """Test derive_unit from expression."""
+
+    class lambda_E(Variable):
+        unit = joule / kilogram
+
+    class E_l(Variable):
+        unit = joule / (meter ** 2 * second)
+
+    assert derive_unit(lambda_E * E_l) == kilogram * meter ** 2 / second ** 5
 
 
 def test_remove_variable_from_registry():

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -69,7 +69,8 @@ def test_derive_unit():
     class E_l(Variable):
         unit = joule / (meter ** 2 * second)
 
-    assert derive_unit(lambda_E * E_l) == kilogram * meter ** 2 / second ** 5
+    assert derive_unit(2 * lambda_E * E_l) \
+        == kilogram * meter ** 2 / second ** 5
 
 
 def test_remove_variable_from_registry():

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -22,6 +22,7 @@ class demo_expression_variable(Variable):
 
 def test_variable_definition():
     """Test variable definition."""
+
     assert demo_variable.definition.default == 1
     assert demo_expression_variable.subs(Variable.__expressions__) \
         == 2 * demo_variable

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -22,7 +22,6 @@ class demo_expression_variable(Variable):
 
 def test_variable_definition():
     """Test variable definition."""
-
     assert demo_variable.definition.default == 1
     assert demo_expression_variable.subs(Variable.__expressions__) \
         == 2 * demo_variable

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -72,6 +72,11 @@ def test_derive_unit():
         == kilogram * meter ** 2 / second ** 5
     assert derive_unit(E_l/E_l) == 1
 
+    class dimensionless(Variable):
+        expr = demo_variable / demo_expression_variable
+
+    assert dimensionless.definition.unit == 1
+
 
 def test_remove_variable_from_registry():
     """Check is the variable is removed from registry."""


### PR DESCRIPTION
On the current master, 2 tests fail:
```
tests/test_variables.py:28: AssertionError
```
and 
```
tests/test_variables.py:51:
...
E                   ValueError: Invalid expression units 3*meter should be meter

essm/variables/_core.py:68: ValueError
```
This is because `derive_unit()` returns the units of an expression multiplied by their scale factor, so a variable definition based on a symbolic expression results in units that contain a numerical value. This PR fixes this.  
