### PR TITLE
Fix to replace_variables

### DIFF
--- a/essm/variables/utils.py
+++ b/essm/variables/utils.py
@@ -54,12 +54,14 @@ def extract_variables(expr):
 
 
 def replace_variables(expr, variables=None):
-    """Replace all base variables in expression."""
+    """Replace all base variables in expression by symbols and substitute
+    dictionary `variables`."""
     if not isinstance(expr, Expr):  # stop recursion
         return expr
 
     variables = {
-        key._name: replace_variables(value)
+        key._name if isinstance(key, BaseVariable) else
+        key: replace_variables(value)
         for key, value in (variables or {}).items()}
 
     return expr.replace(

--- a/essm/variables/utils.py
+++ b/essm/variables/utils.py
@@ -54,8 +54,7 @@ def extract_variables(expr):
 
 
 def replace_variables(expr, variables=None):
-    """Replace all base variables in expression by symbols and substitute
-    dictionary `variables`."""
+    """Replace all base variables in expression by ``variables``."""
     if not isinstance(expr, Expr):  # stop recursion
         return expr
 

--- a/essm/variables/utils.py
+++ b/essm/variables/utils.py
@@ -60,8 +60,7 @@ def replace_variables(expr, variables=None):
         return expr
 
     variables = {
-        key._name if isinstance(key, BaseVariable) else
-        key: replace_variables(value)
+        getattr(key, '_name', key): replace_variables(value)
         for key, value in (variables or {}).items()}
 
     return expr.replace(

--- a/tests/test_equations.py
+++ b/tests/test_equations.py
@@ -2,7 +2,7 @@
 """Test equations."""
 
 import pytest
-from sympy import S
+from sympy import S, Symbol
 
 from essm import Eq
 from essm._generator import EquationWriter
@@ -68,6 +68,7 @@ def test_variable_replacement():
     """Test replace variables by values and symbols in expression."""
     expr = demo_fall.rhs
     vdict = Variable.__defaults__.copy()
+    vdict[Symbol('x')] = 1
     assert replace_variables(expr, vdict) == \
         4.9 * demo_fall.definition.t._name ** 2
 

--- a/tests/test_equations.py
+++ b/tests/test_equations.py
@@ -21,13 +21,13 @@ class demo_g(Variable):
 
 class demo_d(Variable):
     """Test variable."""
-    
+
     unit = meter
 
 
 class demo_fall(Equation):
     """Test equation."""
-    
+
     class t(Variable):
         unit = second
 

--- a/tests/test_equations.py
+++ b/tests/test_equations.py
@@ -19,16 +19,17 @@ class demo_g(Variable):
     unit = meter / second ** 2
 
 
+class demo_d(Variable):
+    """Test variable."""
+    unit = meter
+
+
 class demo_fall(Equation):
     """Test equation."""
-
-    class d(Variable):
-        unit = meter
-
     class t(Variable):
         unit = second
 
-    expr = Eq(d, S(1) / S(2) * demo_g * t ** 2)
+    expr = Eq(demo_d, S(1) / S(2) * demo_g * t ** 2)
 
 
 def test_equation():
@@ -54,7 +55,7 @@ def test_args():
     """Test defined args."""
     assert set(demo_fall.definition.args()) == {
         demo_g.definition,
-        demo_fall.definition.d.definition,
+        demo_d.definition,
         demo_fall.definition.t.definition, }
 
 
@@ -66,11 +67,11 @@ def test_variable_extraction():
 
 def test_variable_replacement():
     """Test replace variables by values and symbols in expression."""
-    expr = demo_fall.rhs
+    expr = demo_fall
     vdict = Variable.__defaults__.copy()
     vdict[Symbol('x')] = 1
     assert replace_variables(expr, vdict) == \
-        4.9 * demo_fall.definition.t._name ** 2
+        Eq(demo_d._name, 4.9 * demo_fall.definition.t._name ** 2)
 
 
 def test_unit_check():

--- a/tests/test_equations.py
+++ b/tests/test_equations.py
@@ -21,11 +21,13 @@ class demo_g(Variable):
 
 class demo_d(Variable):
     """Test variable."""
+    
     unit = meter
 
 
 class demo_fall(Equation):
     """Test equation."""
+    
     class t(Variable):
         unit = second
 


### PR DESCRIPTION
If a dictionary passed to `replace_variables` contains keys that are not `BaseVariable`, an error is raised. To enable use of dictionaries with both `BaseVariable` and `Symbol` as keys, I slightly modified `replace_variables` and the respective test.