### PR TITLE
Added function to replace variables by their default values

### DIFF
--- a/essm/variables/_core.py
+++ b/essm/variables/_core.py
@@ -40,7 +40,7 @@ class VariableMeta(RegistryType):
     def __new__(cls, name, parents, dct):
         """Build and register new variable."""
         if '__registry__' not in dct:
-            unit = dct.pop('unit', None)
+            unit = dct.pop('unit', S.One)
             if unit == 1:
                 unit = S.One
             definition = dct.pop('expr', None)
@@ -58,7 +58,8 @@ class VariableMeta(RegistryType):
                 definition = build_instance_expression(instance, definition)
                 derived_unit = derive_unit(definition, name=name)
 
-                unit = unit or derived_unit  # only if unit is None
+                if unit == S.One:
+                    unit = derived_unit  # only if unit is None
                 instance.expr, instance.unit = definition, derived_unit
 
                 if unit != instance.unit:

--- a/essm/variables/_core.py
+++ b/essm/variables/_core.py
@@ -72,9 +72,9 @@ class VariableMeta(RegistryType):
             expr = BaseVariable(
                 instance,
                 dct['name'],
-                Dimension(Quantity.get_dimensional_expr(unit)),
-                unit or S.One,
                 abbrev=dct['latex_name'],
+                dimension=Dimension(Quantity.get_dimensional_expr(unit)),
+                scale_factor=unit or S.One,
             )
             instance[expr] = instance
 
@@ -119,17 +119,17 @@ class BaseVariable(Quantity):
             cls,
             definition,
             name,
+            abbrev,
             dimension,
             scale_factor=S.One,
-            abbrev=None,
             **assumptions
     ):
         self = super(BaseVariable, cls).__new__(
             cls,
             name,
-            dimension,
-            scale_factor=scale_factor,
             abbrev=abbrev,
+            dimension=dimension,
+            scale_factor=scale_factor,
             **assumptions
         )
         self.definition = definition

--- a/essm/variables/units.py
+++ b/essm/variables/units.py
@@ -35,7 +35,8 @@ pascal = u.pascal
 second = u.second
 watt = u.watt
 
-SI_DIMENSIONS = {str(d._dimension.name): d for d in SI._base_units}
+SI_DIMENSIONS = {
+    str(Quantity.get_dimensional_expr(d)): d for d in SI._base_units}
 
 
 def markdown(unit):

--- a/essm/variables/utils.py
+++ b/essm/variables/utils.py
@@ -69,7 +69,7 @@ def replace_variables(expr, variables=None):
 
 
 def replace_defaults(expr):
-    '''Replace variables in expression by their default values.'''
+    """Replace variables in expression by their default values."""
     if hasattr(expr, 'lhs'):
         expr1 = expr.lhs
         lhs = expr1.replace(

--- a/essm/variables/utils.py
+++ b/essm/variables/utils.py
@@ -66,3 +66,25 @@ def replace_variables(expr, variables=None):
         return Eq(expr.lhs.xreplace(symbols).xreplace(variables),
                   expr.rhs.xreplace(symbols).xreplace(variables))
     return expr.xreplace(symbols).xreplace(variables)
+
+
+def replace_defaults(expr):
+    '''Replace variables in expression by their default values.'''
+    if hasattr(expr, 'lhs'):
+        expr1 = expr.lhs
+        lhs = expr1.replace(
+            lambda expr1: isinstance(expr1, BaseVariable),
+            lambda expr1: expr1.definition.unit*expr1.definition.default
+            if hasattr(expr1.definition, 'default') else expr1)
+        expr1 = expr.rhs
+        rhs = expr1.replace(
+            lambda expr1: isinstance(expr1, BaseVariable),
+            lambda expr1: expr1.definition.unit*expr1.definition.default
+            if hasattr(expr1.definition, 'default') else expr1)
+        return Eq(lhs, rhs)
+    else:
+        expr1 = expr
+        return expr1.replace(
+            lambda expr1: isinstance(expr1, BaseVariable),
+            lambda expr1: expr1.definition.unit*expr1.definition.default
+            if hasattr(expr1.definition, 'default') else expr1)

--- a/tests/test_equations.py
+++ b/tests/test_equations.py
@@ -139,16 +139,6 @@ def test_double_registration():
     assert Equation.__registry__[demo_double].__doc__ == 'Second.'
 
 
-def test_solve_quantity():
-    """Check solving equation for variable."""
-    from sympy import solve
-
-    res = solve(10 ** 6 * demo_d1 - 0.031e6 *
-                Quantity('demo_d', length, meter) + 0.168 *
-                meter, demo_d1)
-    assert res == [0.031*Quantity('demo_d', length, meter) - 1.68e-7*meter]
-
-
 @pytest.mark.skip(reason="needs rewrite for SymPy")
 def test_equation_writer(tmpdir):
     """EquationWriter creates importable file with internal variables."""


### PR DESCRIPTION
Equations often contain variables with default values (e.g. physical constants) and variables without. If we substitute the dictionary with default values into an expression, e.g. `demo_fall.xreplace(Variable.__defaults__)`, we obtain the RHS of the equation with inconsistent units, as the dictionary does not contain the units: `4.9*t**2`
To simplify substitution of default values with their appropriate units into equations, I created the function `replace_defaults()` to variables/utils.py. Usage example:
```
>>> replace_defaults(demo_fall)
Eq(demo_d, 4.9*t**2*meter/second**2)
```
