### PR TITLE
Added code to markdown() enabling better formatting of units.

### DIFF
--- a/essm/variables/units.py
+++ b/essm/variables/units.py
@@ -41,7 +41,33 @@ SI_DIMENSIONS = {
 
 def markdown(unit):
     """Return markdown representation of a unit."""
-    return str(unit)
+    from sympy.printing import StrPrinter
+    from operator import itemgetter
+    # displays short units (m instead of meter)
+    StrPrinter._print_Quantity = lambda self, expr: str(expr.abbrev)
+    if unit.is_Pow:
+        item = unit.args
+        return '{0}$^{{{1}}}$'.format(item[0], item[1])
+    if unit.is_Mul:
+        str1 = ''
+        tuples = []
+        allargs = unit.args
+        for arg in allargs:
+            if arg.is_Pow:
+                args = arg.args
+                tuples.append((str(args[0]), args[1]))
+            if isinstance(arg, Quantity):
+                tuples.append((str(arg), 1))
+        tuples.sort(key=itemgetter(1), reverse=True)
+        tuples.sort(key=itemgetter(0))
+        for item in tuples:
+            if item[1] == 1:
+                str1 = str1 + ' ' + item[0]
+            else:
+                str1 = str1 + ' {0}$^{{{1}}}$'.format(item[0], item[1])
+        return str1.strip()
+    else:
+        return str(unit)
 
 
 def unit_symbols(expr):

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -111,5 +111,4 @@ def test_remove_variable_from_registry():
 
 def test_markdown():
     """Check markdown representation of units."""
-
     assert markdown(kilogram*meter/second**2) == 'kg m s$^{-2}$'

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -4,7 +4,8 @@
 import pytest
 
 from essm.variables import Variable
-from essm.variables.units import derive_unit, joule, kilogram, meter, second
+from essm.variables.units import derive_unit, joule, kilogram, markdown,\
+    meter, second
 from sympy import Eq
 
 
@@ -106,3 +107,9 @@ def test_remove_variable_from_registry():
 
     with pytest.raises(KeyError):
         del Variable[removable]
+
+
+def test_markdown():
+    """Check markdown representation of units."""
+
+    assert markdown(kilogram*meter/second**2) == 'kg m s$^{-2}$'


### PR DESCRIPTION
This restores the previous functionality we had in the SageMath-based version, where units were formatted as e.g. `kg m s${-2}` instead of `kg*m/s**2`, using `markdown(unit)`.