### PR TITLE
fixed generate_metadata_table

### DIFF
--- a/essm/variables/utils.py
+++ b/essm/variables/utils.py
@@ -31,10 +31,13 @@ from .units import markdown
 class ListTable(list):
     """Override list class to render HTML Table in Jupyter notbook.
 
-    Takes a 2-dimensional list of the form [[1,2,3],[4,5,6]],
-    and renders an HTML Table in IPython Notebook. Source:
-    From: https://calebmadrigal.com/display-list-as-table-in-ipython-notebook
+    Takes a 2-dimensional list of the form ``[[1, 2, 3], [4, 5, 6]],``
+    and renders an HTML Table in IPython Notebook.
+
+    Source: https://calebmadrigal.com/display-list-as-table-in-ipython-notebook
+
     Example:
+    
     >>> table = ListTable()
     >>> table.append(['Column1', 'Column2'])
     >>> table.append(['1', '2'])
@@ -63,8 +66,8 @@ def generate_metadata_table(variables=None, include_header=True):
     table = ListTable()
     variables = variables or Variable.__registry__.keys()
     if include_header:
-        table.append(['Symbol', 'Name', 'Description',
-                      'Default value', 'Units'])
+        table.append(('Symbol', 'Name', 'Description',
+                      'Default value', 'Units'))
 
     for variable in sorted(variables, key=lambda x:
                            x.definition.latex_name.lower()):
@@ -73,8 +76,8 @@ def generate_metadata_table(variables=None, include_header=True):
         doc = variable.__doc__
         val = str(Variable.__defaults__.get(variable, '-'))
 
-        table.append([symbol, name, doc, val,
-                      markdown(variable.definition.unit)])
+        table.append((symbol, name, doc, val,
+                      markdown(variable.definition.unit)))
     return table
 
 

--- a/essm/variables/utils.py
+++ b/essm/variables/utils.py
@@ -37,7 +37,7 @@ class ListTable(list):
     Source: https://calebmadrigal.com/display-list-as-table-in-ipython-notebook
 
     Example:
-    
+
     >>> table = ListTable()
     >>> table.append(['Column1', 'Column2'])
     >>> table.append(['1', '2'])

--- a/essm/variables/utils.py
+++ b/essm/variables/utils.py
@@ -30,7 +30,7 @@ from .units import markdown
 
 class ListTable(list):
     """Override list class to render HTML Table in Jupyter notbook.
-    
+
     Takes a 2-dimensional list of the form [[1,2,3],[4,5,6]],
     and renders an HTML Table in IPython Notebook. Source:
     From: https://calebmadrigal.com/display-list-as-table-in-ipython-notebook

--- a/essm/variables/utils.py
+++ b/essm/variables/utils.py
@@ -41,7 +41,7 @@ class ListTable(list):
     >>> table
     [['Column1', 'Column2'], ['1', '2']]
     """
-    
+
     def _repr_html_(self):
         html = ["<table>"]
         for row in self:

--- a/essm/variables/utils.py
+++ b/essm/variables/utils.py
@@ -29,9 +29,9 @@ from .units import markdown
 
 
 class ListTable(list):
-    """ Overridden list class which takes a 2-dimensional list of
-        the form [[1,2,3],[4,5,6]], and renders an HTML Table in
-        IPython Notebook.
+    """ Override list class to render HTML Table in Jupyter notbook.
+        Takes a 2-dimensional list of the form [[1,2,3],[4,5,6]],
+        and renders an HTML Table in IPython Notebook. Source:
         https://calebmadrigal.com/display-list-as-table-in-ipython-notebook/
         Example:
         >>> table = ListTable()
@@ -40,7 +40,6 @@ class ListTable(list):
         >>> table
         [['Column1', 'Column2'], ['1', '2']]
     """
-
     def _repr_html_(self):
         html = ["<table>"]
         for row in self:

--- a/essm/variables/utils.py
+++ b/essm/variables/utils.py
@@ -41,6 +41,7 @@ class ListTable(list):
     >>> table
     [['Column1', 'Column2'], ['1', '2']]
     """
+    
     def _repr_html_(self):
         html = ["<table>"]
         for row in self:

--- a/essm/variables/utils.py
+++ b/essm/variables/utils.py
@@ -29,16 +29,17 @@ from .units import markdown
 
 
 class ListTable(list):
-    """ Override list class to render HTML Table in Jupyter notbook.
-        Takes a 2-dimensional list of the form [[1,2,3],[4,5,6]],
-        and renders an HTML Table in IPython Notebook. Source:
-        https://calebmadrigal.com/display-list-as-table-in-ipython-notebook/
-        Example:
-        >>> table = ListTable()
-        >>> table.append(['Column1', 'Column2'])
-        >>> table.append(['1', '2'])
-        >>> table
-        [['Column1', 'Column2'], ['1', '2']]
+    """Override list class to render HTML Table in Jupyter notbook.
+    
+    Takes a 2-dimensional list of the form [[1,2,3],[4,5,6]],
+    and renders an HTML Table in IPython Notebook. Source:
+    From: https://calebmadrigal.com/display-list-as-table-in-ipython-notebook
+    Example:
+    >>> table = ListTable()
+    >>> table.append(['Column1', 'Column2'])
+    >>> table.append(['1', '2'])
+    >>> table
+    [['Column1', 'Column2'], ['1', '2']]
     """
     def _repr_html_(self):
         html = ["<table>"]

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -120,7 +120,7 @@ def test_markdown():
 def test_generate_metadata_table():
     """Check display of table of units."""
     assert generate_metadata_table([E_l, lambda_E]) \
-        == [['Symbol', 'Name', 'Description', 'Default value', 'Units'],
-            ['$\\lambda_E$', 'lambda_E', 'Latent heat of evaporation.',
-            '2450000.0', 'J kg$^{-1}$'], ['$E_l$', 'E_l',
-            'Latent heat flux from leaf.', '-', 'J m$^{-2}$ s$^{-1}$']]
+        == [('Symbol', 'Name', 'Description', 'Default value', 'Units'),
+            ('$\\lambda_E$', 'lambda_E', 'Latent heat of evaporation.',
+            '2450000.0', 'J kg$^{-1}$'), ('$E_l$', 'E_l',
+            'Latent heat flux from leaf.', '-', 'J m$^{-2}$ s$^{-1}$')]

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -114,13 +114,11 @@ def test_remove_variable_from_registry():
 
 def test_markdown():
     """Check markdown representation of units."""
-
     assert markdown(kilogram * meter / second ** 2) == 'kg m s$^{-2}$'
 
 
 def test_generate_metadata_table():
     """Check display of table of units."""
-
     assert generate_metadata_table([E_l, lambda_E]) \
         == [['Symbol', 'Name', 'Description', 'Default value', 'Units'],
             ['$\\lambda_E$', 'lambda_E', 'Latent heat of evaporation.',

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -6,6 +6,7 @@ import pytest
 from essm.variables import Variable
 from essm.variables.units import derive_unit, joule, kilogram, markdown,\
     meter, second
+from essm.variables.utils import generate_metadata_table
 from sympy import Eq
 
 
@@ -20,6 +21,14 @@ class demo_expression_variable(Variable):
     """Test expression variable."""
 
     expr = 2 * demo_variable
+
+
+class lambda_E(Variable):
+    unit = joule / kilogram
+
+
+class E_l(Variable):
+    unit = joule / (meter ** 2 * second)
 
 
 def test_variable_definition():
@@ -78,15 +87,9 @@ def test_symbolic():
 def test_derive_unit():
     """Test derive_unit from expression."""
 
-    class lambda_E(Variable):
-        unit = joule / kilogram
-
-    class E_l(Variable):
-        unit = joule / (meter ** 2 * second)
-
     assert derive_unit(2 * lambda_E * E_l) \
         == kilogram * meter ** 2 / second ** 5
-    assert derive_unit(E_l/E_l) == 1
+    assert derive_unit(E_l / E_l) == 1
 
     class dimensionless(Variable):
         expr = demo_variable / demo_expression_variable
@@ -111,4 +114,15 @@ def test_remove_variable_from_registry():
 
 def test_markdown():
     """Check markdown representation of units."""
-    assert markdown(kilogram*meter/second**2) == 'kg m s$^{-2}$'
+
+    assert markdown(kilogram * meter / second ** 2) == 'kg m s$^{-2}$'
+
+
+def test_generate_metadata_table():
+    """Check display of table of units."""
+
+    assert generate_metadata_table([E_l, lambda_E]) \
+        == [['Symbol', 'Name', 'Description', 'Default value', 'Units'],
+            ['$\\lambda_E$', 'lambda_E', 'Latent heat of evaporation.',
+            '2450000.0', 'J kg$^{-1}$'], ['$E_l$', 'E_l',
+            'Latent heat flux from leaf.', '-', 'J m$^{-2}$ s$^{-1}$']]


### PR DESCRIPTION
The function `generate_metadata_table` in essm/variables/utils.py was dysfunctional. I fixed it now to enable nicely formatted html tables of variables in jupyter notebook.