### PR TITLE
Latex variable

### DIFF
--- a/essm/variables/_core.py
+++ b/essm/variables/_core.py
@@ -195,6 +195,9 @@ class BaseVariable(Symbol):
     def __doc__(self):
         return self.definition.__doc__
 
+    def _latex(self, printer):
+        return self.definition.latex_name
+
 
 Basic._constructor_postprocessor_mapping[BaseVariable] = {
     "Add": [_Quantity_constructor_postprocessor_Add],

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -121,6 +121,18 @@ def test_remove_variable_from_registry():
         del Variable[removable]
 
 
+def test_latex():
+    """Test latex representaiton of variables."""
+
+    from sympy import latex
+
+    class lmbda(Variable):
+        """Test variable."""
+        latex_name = 'L'
+
+    assert latex(lmbda) == 'L'
+
+
 def test_markdown():
     """Check markdown representation of units."""
     assert markdown(kilogram * meter / second ** 2) == 'kg m s$^{-2}$'


### PR DESCRIPTION
Variable definitions allow for a dictionary entry `latex_name`, but it did not have an effect so far. This PR adds a method for `latex(variable1)` to use `latex_name`.