### PR TITLE
Small changes to adapt to Python 3.7 and Sympy >=1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,5 +66,5 @@ deploy:
   distributions: "sdist bdist_wheel"
   on:
     tags: true
-    python: "2.7"
+    python: "3.7"
     repo: environmentalscience/essm

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ language: python
 python:
   - '2.7'
   - '3.6'
+  - '3.7'
 
 sudo: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ language: python
 python:
   - '2.7'
   - '3.6'
-  - '3.7'
 
 sudo: true
 
@@ -67,5 +66,5 @@ deploy:
   distributions: "sdist bdist_wheel"
   on:
     tags: true
-    python: "3.7"
+    python: "3.6"
     repo: environmentalscience/essm

--- a/essm/variables/_core.py
+++ b/essm/variables/_core.py
@@ -205,9 +205,11 @@ class BaseVariable(Symbol):
 
 
 def _Quantity_constructor_postprocessor_Add(expr):
-    # Construction postprocessor for the addition,
-    # checks for dimension mismatches of the addends, thus preventing
-    # expressions like `meter + second` to be created.
+    """Construction postprocessor for the addition.
+    
+    It checks for dimension mismatches of the addends, thus preventing
+    expressions like ``meter + second`` to be created.
+    """
 
     deset = {
         tuple(sorted(Dimension(

--- a/essm/variables/_core.py
+++ b/essm/variables/_core.py
@@ -206,11 +206,10 @@ class BaseVariable(Symbol):
 
 def _Quantity_constructor_postprocessor_Add(expr):
     """Construction postprocessor for the addition.
-    
+
     It checks for dimension mismatches of the addends, thus preventing
     expressions like ``meter + second`` to be created.
     """
-
     deset = {
         tuple(sorted(Dimension(
             Quantity.get_dimensional_expr(i) if not i.is_number else 1

--- a/essm/variables/_core.py
+++ b/essm/variables/_core.py
@@ -205,7 +205,7 @@ class BaseVariable(Symbol):
 
 
 def _Quantity_constructor_postprocessor_Add(expr):
-    """Construction postprocessor for the addition.
+    """Construct postprocessor for the addition.
 
     It checks for dimension mismatches of the addends, thus preventing
     expressions like ``meter + second`` to be created.

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,6 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Development Status :: 1 - Planning',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup_requires = [
 ]
 
 install_requires = [
-    'sympy>=1.1.2.dev',
+    'sympy>=1.3',
     'six>=1.10.0',
 ]
 
@@ -94,6 +94,7 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.7',
         'Development Status :: 1 - Planning',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,8 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Development Status :: 1 - Planning',
     ],


### PR DESCRIPTION
In Sympy 1.3 `_Quantity_constructor_postprocessor_Add` was removed, so the import does not work any more. I included the function in `variables/_core.py` now. I also changed the version requirements to include Python 3.7 and Sympy 1.3.