### PR TITLE
fix latex representation of x_O2 as x_{O2} instead of x_{N2}.

### DIFF
--- a/essm/variables/physics/thermodynamics.py
+++ b/essm/variables/physics/thermodynamics.py
@@ -368,7 +368,7 @@ class x_O2(Variable):
 
     name = 'x_O2'
     domain = 'real'
-    latex_name = 'x_{N2}'
+    latex_name = 'x_{O2}'
     default = 0.210000000000000
 
 


### PR DESCRIPTION
Fixes https://github.com/environmentalscience/essm/issues/58