### PR TITLE
Add support for Integral and Piecewise in Equation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ env:
 
 before_install:
   - git fetch --tags
-  - travis_retry pip install twine wheel coveralls
+  - travis_retry pip install -U twine wheel coveralls pip
   - travis_retry pip install check-manifest pydocstyle
   - travis_retry pip install -r requirements-devel.txt
 

--- a/essm/_generator.py
+++ b/essm/_generator.py
@@ -127,8 +127,8 @@ def create_module(name, doc=None, folder=None, overwrite=False):
 
 class VariableWriter(object):
     """Generate Variable definitions.
-    Example:
 
+    Example:
     .. code-block:: python
         from essm._generator import VariableWriter
 
@@ -220,8 +220,8 @@ class VariableWriter(object):
 
 class EquationWriter(object):
     r"""Generate Equation definitions.
-    Example:
 
+    Example:
     .. code-block:: python
 
         from essm.equations import Equation

--- a/essm/_generator.py
+++ b/essm/_generator.py
@@ -131,7 +131,7 @@ class VariableWriter(object):
     Example:
 
     .. code-block:: python
-        from essm._generator import VariableWriter
+       from essm._generator import VariableWriter
     """
 
     TPL = VARIABLE_TPL

--- a/essm/_generator.py
+++ b/essm/_generator.py
@@ -129,9 +129,9 @@ class VariableWriter(object):
     """Generate Variable definitions.
 
     Example:
+
     .. code-block:: python
         from essm._generator import VariableWriter
-
     """
 
     TPL = VARIABLE_TPL
@@ -222,6 +222,7 @@ class EquationWriter(object):
     r"""Generate Equation definitions.
 
     Example:
+
     .. code-block:: python
 
         from essm.equations import Equation
@@ -243,7 +244,6 @@ class EquationWriter(object):
                                {"name": "p_Dva2", "value": '1.96e-05',
                                 "units": meter^2/second}])
         print(writer)
-
     """
 
     TPL = EQUATION_TPL

--- a/essm/_generator.py
+++ b/essm/_generator.py
@@ -127,11 +127,11 @@ def create_module(name, doc=None, folder=None, overwrite=False):
 
 class VariableWriter(object):
     """Generate Variable definitions.
-
     Example:
 
     .. code-block:: python
         from essm._generator import VariableWriter
+
     """
 
     TPL = VARIABLE_TPL
@@ -220,7 +220,6 @@ class VariableWriter(object):
 
 class EquationWriter(object):
     r"""Generate Equation definitions.
-
     Example:
 
     .. code-block:: python
@@ -244,6 +243,7 @@ class EquationWriter(object):
                                {"name": "p_Dva2", "value": '1.96e-05',
                                 "units": meter^2/second}])
         print(writer)
+
     """
 
     TPL = EQUATION_TPL

--- a/essm/equations/_core.py
+++ b/essm/equations/_core.py
@@ -43,7 +43,6 @@ class EquationMeta(RegistryType):
     Example:
 
     .. code-block:: python
-
        from ..variables.units import meter, second
        class test(Equation):
            '''Test equation.'''

--- a/essm/equations/_core.py
+++ b/essm/equations/_core.py
@@ -43,6 +43,7 @@ class EquationMeta(RegistryType):
     Example:
 
     .. code-block:: python
+
        from ..variables.units import meter, second
        class test(Equation):
            '''Test equation.'''

--- a/essm/equations/_core.py
+++ b/essm/equations/_core.py
@@ -36,7 +36,6 @@ from ..variables._core import BaseVariable, Variable
 
 class EquationMeta(RegistryType):
     r"""Equation interface.
-
     Defines an equation with a docstring and internal variables,
     if needed.
 
@@ -91,6 +90,7 @@ class EquationMeta(RegistryType):
         .. testoutput::
 
            ValueError: Invalid expression units: meter/second == meter*second
+
     """
 
     def __new__(cls, name, parents, dct):

--- a/essm/equations/_core.py
+++ b/essm/equations/_core.py
@@ -132,8 +132,7 @@ class BaseEquation(Eq):
         if not isinstance(expr, Eq):
             return expr
         # The below raises an error if units are not consistent
-        Variable.collect_factor_and_basedimension(expr.lhs + expr.rhs)
-        #derive_baseunit(expr.lhs + expr.rhs)
+        Variable.check_unit(expr.lhs + expr.rhs)
         self = super(BaseEquation, cls).__new__(cls, *expr.args)
         self.definition = definition
         return self

--- a/essm/equations/_core.py
+++ b/essm/equations/_core.py
@@ -41,6 +41,7 @@ class EquationMeta(RegistryType):
     if needed.
 
     Example:
+
     .. code-block:: python
 
        from ..variables.units import meter, second
@@ -63,32 +64,33 @@ class EquationMeta(RegistryType):
 
     :raises ValueError: if the units are inconsistent.
 
-        Example:
-        .. testcode:: python
+    Example:
 
-           from ..variables.units import meter, second
-           class test(Equation):
-               '''Test equation with inconsistent units.'''
+    .. testcode:: python
 
-               class d(Variable):
-                   '''Internal variable.'''
-                   unit = meter
+       from ..variables.units import meter, second
+       class test(Equation):
+           '''Test equation with inconsistent units.'''
 
-               class t(Variable):
-                   '''Internal variable.'''
-                   unit = second
+           class d(Variable):
+               '''Internal variable.'''
+               unit = meter
 
-               class v(Variable):
-                   '''Internal variable.'''
-                   unit = meter/second
+           class t(Variable):
+               '''Internal variable.'''
+               unit = second
 
-               expr = v == d * t
+           class v(Variable):
+               '''Internal variable.'''
+               unit = meter/second
 
-        Since the units of v and d*t are not the same, this returns:
+           expr = v == d * t
 
-        .. testoutput::
+    Since the units of v and d*t are not the same, this returns:
 
-           ValueError: Invalid expression units: meter/second == meter*second
+    .. testoutput::
+
+       ValueError: Invalid expression units: meter/second == meter*second
 
     """
 
@@ -156,6 +158,7 @@ class BaseEquation(Eq):
         r"""Return a new equation with subs applied to both sides.
 
         **Examples:**
+
         >>> from essm.equations.leaf.energy_water import (
         ... eq_Rs_enbal, eq_El, eq_Hl, eq_Rll )
         >>> eq_Rs_enbal.subs(eq_El, eq_Hl, eq_Rll)

--- a/essm/equations/_core.py
+++ b/essm/equations/_core.py
@@ -43,23 +43,23 @@ class EquationMeta(RegistryType):
     Example:
     .. code-block:: python
 
-        from ..variables.units import meter, second
-        class test(Equation):
-            '''Test equation.'''
+       from ..variables.units import meter, second
+       class test(Equation):
+           '''Test equation.'''
 
-            class d(Variable):
-                '''Internal variable.'''
-                unit = meter
+           class d(Variable):
+               '''Internal variable.'''
+               unit = meter
 
-            class t(Variable):
-                '''Internal variable.'''
-                unit = second
+           class t(Variable):
+               '''Internal variable.'''
+               unit = second
 
-            class v(Variable):
-                '''Internal variable.'''
-                unit = meter/second
+           class v(Variable):
+               '''Internal variable.'''
+               unit = meter/second
 
-            expr = v == d / t
+           expr = v == d / t
 
     :raises ValueError: if the units are inconsistent.
 

--- a/essm/equations/_core.py
+++ b/essm/equations/_core.py
@@ -36,11 +36,11 @@ from ..variables._core import BaseVariable, Variable
 
 class EquationMeta(RegistryType):
     r"""Equation interface.
+
     Defines an equation with a docstring and internal variables,
     if needed.
 
     Example:
-
     .. code-block:: python
 
         from ..variables.units import meter, second
@@ -64,7 +64,6 @@ class EquationMeta(RegistryType):
     :raises ValueError: if the units are inconsistent.
 
         Example:
-
         .. testcode:: python
 
            from ..variables.units import meter, second
@@ -157,7 +156,6 @@ class BaseEquation(Eq):
         r"""Return a new equation with subs applied to both sides.
 
         **Examples:**
-
         >>> from essm.equations.leaf.energy_water import (
         ... eq_Rs_enbal, eq_El, eq_Hl, eq_Rll )
         >>> eq_Rs_enbal.subs(eq_El, eq_Hl, eq_Rll)

--- a/essm/equations/_core.py
+++ b/essm/equations/_core.py
@@ -30,6 +30,7 @@ from sympy.core.relational import Eq
 from ..bases import RegistryType
 from ..transformer import build_instance_expression
 from ..variables import Variable
+from ..variables.units import derive_baseunit
 from ..variables._core import BaseVariable, Variable
 
 
@@ -132,6 +133,7 @@ class BaseEquation(Eq):
             return expr
         # The below raises an error if units are not consistent
         Variable.collect_factor_and_basedimension(expr.lhs + expr.rhs)
+        #derive_baseunit(expr.lhs + expr.rhs)
         self = super(BaseEquation, cls).__new__(cls, *expr.args)
         self.definition = definition
         return self

--- a/essm/variables/__init__.py
+++ b/essm/variables/__init__.py
@@ -18,7 +18,6 @@
 # Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 # MA 02111-1307, USA.
 """Variables module to deal with physical variables and units.
-
 It allows attaching docstrings to variable names, defining their domains
 (e.g. integer, real or complex), their units and LaTeX representations.
 You can also provide a default value, which is particularly useful for

--- a/essm/variables/__init__.py
+++ b/essm/variables/__init__.py
@@ -18,6 +18,7 @@
 # Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 # MA 02111-1307, USA.
 """Variables module to deal with physical variables and units.
+
 It allows attaching docstrings to variable names, defining their domains
 (e.g. integer, real or complex), their units and LaTeX representations.
 You can also provide a default value, which is particularly useful for
@@ -37,7 +38,6 @@ Then you can define a custom variable with its name, description, domain,
 latex_name, unit, and an optional default value.
 
 Example:
-
 .. code-block:: python
 
    from .variables.units import meter

--- a/essm/variables/_core.py
+++ b/essm/variables/_core.py
@@ -217,7 +217,7 @@ class Variable(object):
         elif isinstance(expr, Integral):
             # Test that integration limits have the same units
             Variable.collect_factor_and_basedimension(sum(expr.args[1]))
-            factor, dim = Variable.collect_factor_and_basedimension(
+            factor, dim = \
                 Variable.collect_factor_and_basedimension(expr.args[0] *
                                                           expr.args[1][0])
             return factor, dim

--- a/essm/variables/_core.py
+++ b/essm/variables/_core.py
@@ -155,70 +155,70 @@ class Variable(object):
         factor, dim = Variable.collect_factor_and_basedimension(expr)
         return expr
 
-@staticmethod
-def collect_factor_and_basedimension(expr):
-    """Return tuple with factor expression and dimension expression."""
-    if isinstance(expr, BaseVariable):
-        expr = expr.definition.unit
-    if isinstance(expr, Quantity):
-        return expr.scale_factor, derive_base_dimension(expr.dimension)
-    elif isinstance(expr, Mul):
-        factor = 1
-        dimension = Dimension(1)
-        for arg in expr.args:
-            arg_factor, arg_dim = \
-                collect_factor_and_basedimension(arg)
-            factor *= arg_factor
-            dimension *= arg_dim
-        return factor, dimension
-    elif isinstance(expr, Pow):
-        factor, dim = collect_factor_and_basedimension(expr.base)
-        exp_factor, exp_dim = \
-            collect_factor_and_basedimension(expr.exp)
-        if exp_dim.is_dimensionless:
-            exp_dim = 1
-        
-        #pytest.set_trace()
-        return factor ** exp_factor, derive_base_dimension(
-            dim ** (exp_factor * exp_dim)
-            ).simplify()
-    elif isinstance(expr, Add):
-        factor, dim = \
-            collect_factor_and_basedimension(expr.args[0])
-        for addend in expr.args[1:]:
-            addend_factor, addend_dim = \
-                collect_factor_and_basedimension(addend)
-            if dim != addend_dim:
-                raise ValueError(
-                    'Dimension of "{0}" is {1}, '
-                    'but it should be the same as {2}, i.e. {3}'.format(
-                        addend, addend_dim, expr.args[0], dim))
-            factor += addend_factor
-        return factor, dim
-    elif isinstance(expr, Derivative):
-        factor, dim = \
-            collect_factor_and_basedimension(expr.args[0])
-        for independent, count in expr.variable_count:
-            ifactor, idim = \
-                collect_factor_and_basedimension(independent)
-            factor /= ifactor**count
-            dim /= idim**count
-        return factor, dim
-    elif isinstance(expr, Integral):
-        # Test that integration limits have the same units
-        collect_factor_and_basedimension(sum(expr.args[1]))
-        factor, dim = \
-            collect_factor_and_basedimension(expr.args[0]*expr.args[1][0])
-        return factor, dim    
-    elif isinstance(expr, Function):
-        fds = [collect_factor_and_basedimension(
-            arg) for arg in expr.args]
-        return (expr.func(*(f[0] for f in fds)),
-                expr.func(*(d[1] for d in fds)))
-    elif isinstance(expr, Dimension):
-        return 1, expr
-    else:
-        return expr, Dimension(1)
+    @staticmethod
+    def collect_factor_and_basedimension(expr):
+        """Return tuple with factor expression and dimension expression."""
+        if isinstance(expr, BaseVariable):
+            expr = expr.definition.unit
+        if isinstance(expr, Quantity):
+            return expr.scale_factor, derive_base_dimension(expr.dimension)
+        elif isinstance(expr, Mul):
+            factor = 1
+            dimension = Dimension(1)
+            for arg in expr.args:
+                arg_factor, arg_dim = \
+                    collect_factor_and_basedimension(arg)
+                factor *= arg_factor
+                dimension *= arg_dim
+            return factor, dimension
+        elif isinstance(expr, Pow):
+            factor, dim = collect_factor_and_basedimension(expr.base)
+            exp_factor, exp_dim = \
+                collect_factor_and_basedimension(expr.exp)
+            if exp_dim.is_dimensionless:
+                exp_dim = 1
+            
+            #pytest.set_trace()
+            return factor ** exp_factor, derive_base_dimension(
+                dim ** (exp_factor * exp_dim)
+                ).simplify()
+        elif isinstance(expr, Add):
+            factor, dim = \
+                collect_factor_and_basedimension(expr.args[0])
+            for addend in expr.args[1:]:
+                addend_factor, addend_dim = \
+                    collect_factor_and_basedimension(addend)
+                if dim != addend_dim:
+                    raise ValueError(
+                        'Dimension of "{0}" is {1}, '
+                        'but it should be the same as {2}, i.e. {3}'.format(
+                            addend, addend_dim, expr.args[0], dim))
+                factor += addend_factor
+            return factor, dim
+        elif isinstance(expr, Derivative):
+            factor, dim = \
+                collect_factor_and_basedimension(expr.args[0])
+            for independent, count in expr.variable_count:
+                ifactor, idim = \
+                    collect_factor_and_basedimension(independent)
+                factor /= ifactor**count
+                dim /= idim**count
+            return factor, dim
+        elif isinstance(expr, Integral):
+            # Test that integration limits have the same units
+            collect_factor_and_basedimension(sum(expr.args[1]))
+            factor, dim = \
+                collect_factor_and_basedimension(expr.args[0]*expr.args[1][0])
+            return factor, dim    
+        elif isinstance(expr, Function):
+            fds = [collect_factor_and_basedimension(
+                arg) for arg in expr.args]
+            return (expr.func(*(f[0] for f in fds)),
+                    expr.func(*(d[1] for d in fds)))
+        elif isinstance(expr, Dimension):
+            return 1, expr
+        else:
+            return expr, Dimension(1)
 
 
 class BaseVariable(Symbol):

--- a/essm/variables/_core.py
+++ b/essm/variables/_core.py
@@ -27,7 +27,7 @@ import warnings
 import six
 
 from sympy import (Abs, Add, Basic, Derivative, Function, Integral, Mul,
-                   Pow, S, Symbol)
+                   Piecewise, Pow, S, Symbol)
 from sympy.physics.units import Dimension, Quantity, convert_to
 from sympy.physics.units.dimensions import dimsys_default, dimsys_SI
 
@@ -209,6 +209,11 @@ class Variable(object):
             factor, dim = \
                 Variable.collect_factor_and_basedimension(expr.args[0] *
                                                           expr.args[1][0])
+            return factor, dim
+        elif isinstance(expr, Piecewise):
+            factor, dim = \
+                Variable.collect_factor_and_basedimension(
+                    sum([x[0] for x in expr.args]))
             return factor, dim
         elif isinstance(expr, Function):
             fds = [Variable.collect_factor_and_basedimension(

--- a/essm/variables/_core.py
+++ b/essm/variables/_core.py
@@ -26,10 +26,11 @@ import warnings
 
 import six
 
-from sympy import (Abs, Add, Basic, Derivative, Function, Integral, Mul,
+from sympy import (Abs, Add, Basic, Derivative, Function, Integral, log, Mul,
                    Piecewise, Pow, S, Symbol)
 from sympy.physics.units import Dimension, Quantity, convert_to
 from sympy.physics.units.dimensions import dimsys_default, dimsys_SI
+from sympy.physics.units.util import check_dimensions
 
 from ..bases import RegistryType
 from ..transformer import build_instance_expression
@@ -65,10 +66,10 @@ class VariableMeta(RegistryType):
                 instance.expr, instance.unit = definition, unit
 
                 dim_derived = dimsys_SI.get_dimensional_dependencies(
-                    Quantity.get_dimensional_expr(derived_unit)
+                    Variable.get_dimensional_expr(derived_unit)
                 )
                 dim_unit = dimsys_SI.get_dimensional_dependencies(
-                    Quantity.get_dimensional_expr(unit)
+                    Variable.get_dimensional_expr(unit)
                 )
                 if dim_derived != dim_unit:
                     raise ValueError(
@@ -190,6 +191,8 @@ class Variable(object):
             return factor ** exp_factor, derive_base_dimension(
                 dim ** (exp_factor * exp_dim)
                 ).simplify()
+        elif isinstance(expr, log):
+            return expr, Dimension(1)
         elif isinstance(expr, Add):
             factor, dim = \
                 Variable.collect_factor_and_basedimension(expr.args[0])

--- a/essm/variables/_core.py
+++ b/essm/variables/_core.py
@@ -155,62 +155,70 @@ class Variable(object):
         factor, dim = Variable.collect_factor_and_basedimension(expr)
         return expr
 
-    @staticmethod
-    def collect_factor_and_basedimension(expr):
-        """Return tuple with factor expression and dimension expression."""
-        if isinstance(expr, BaseVariable):
-            expr = expr.definition.unit
-        if isinstance(expr, Quantity):
-            return expr.scale_factor, derive_base_dimension(expr.dimension)
-        elif isinstance(expr, Mul):
-            factor = 1
-            dimension = Dimension(1)
-            for arg in expr.args:
-                arg_factor, arg_dim = \
-                    Variable.collect_factor_and_basedimension(arg)
-                factor *= arg_factor
-                dimension *= arg_dim
-            return factor, dimension
-        elif isinstance(expr, Pow):
-            factor, dim = Variable.collect_factor_and_basedimension(expr.base)
-            exp_factor, exp_dim = \
-                Variable.collect_factor_and_basedimension(expr.exp)
-            if exp_dim.is_dimensionless:
-                exp_dim = 1
-            return factor ** exp_factor, derive_base_dimension(
-                dim ** (exp_factor * exp_dim)
-                )
-        elif isinstance(expr, Add):
-            factor, dim = \
-                Variable.collect_factor_and_basedimension(expr.args[0])
-            for addend in expr.args[1:]:
-                addend_factor, addend_dim = \
-                    Variable.collect_factor_and_basedimension(addend)
-                if dim != addend_dim:
-                    raise ValueError(
-                        'Dimension of "{0}" is {1}, '
-                        'but it should be the same as {2}, i.e. {3}'.format(
-                            addend, addend_dim, expr.args[0], dim))
-                factor += addend_factor
-            return factor, dim
-        elif isinstance(expr, Derivative):
-            factor, dim = \
-                Variable.collect_factor_and_basedimension(expr.args[0])
-            for independent, count in expr.variable_count:
-                ifactor, idim = \
-                    Variable.collect_factor_and_basedimension(independent)
-                factor /= ifactor**count
-                dim /= idim**count
-            return factor, dim
-        elif isinstance(expr, Function):
-            fds = [Variable.collect_factor_and_basedimension(
-                arg) for arg in expr.args]
-            return (expr.func(*(f[0] for f in fds)),
-                    expr.func(*(d[1] for d in fds)))
-        elif isinstance(expr, Dimension):
-            return 1, expr
-        else:
-            return expr, Dimension(1)
+@staticmethod
+def collect_factor_and_basedimension(expr):
+    """Return tuple with factor expression and dimension expression."""
+    if isinstance(expr, BaseVariable):
+        expr = expr.definition.unit
+    if isinstance(expr, Quantity):
+        return expr.scale_factor, derive_base_dimension(expr.dimension)
+    elif isinstance(expr, Mul):
+        factor = 1
+        dimension = Dimension(1)
+        for arg in expr.args:
+            arg_factor, arg_dim = \
+                collect_factor_and_basedimension(arg)
+            factor *= arg_factor
+            dimension *= arg_dim
+        return factor, dimension
+    elif isinstance(expr, Pow):
+        factor, dim = collect_factor_and_basedimension(expr.base)
+        exp_factor, exp_dim = \
+            collect_factor_and_basedimension(expr.exp)
+        if exp_dim.is_dimensionless:
+            exp_dim = 1
+        
+        #pytest.set_trace()
+        return factor ** exp_factor, derive_base_dimension(
+            dim ** (exp_factor * exp_dim)
+            ).simplify()
+    elif isinstance(expr, Add):
+        factor, dim = \
+            collect_factor_and_basedimension(expr.args[0])
+        for addend in expr.args[1:]:
+            addend_factor, addend_dim = \
+                collect_factor_and_basedimension(addend)
+            if dim != addend_dim:
+                raise ValueError(
+                    'Dimension of "{0}" is {1}, '
+                    'but it should be the same as {2}, i.e. {3}'.format(
+                        addend, addend_dim, expr.args[0], dim))
+            factor += addend_factor
+        return factor, dim
+    elif isinstance(expr, Derivative):
+        factor, dim = \
+            collect_factor_and_basedimension(expr.args[0])
+        for independent, count in expr.variable_count:
+            ifactor, idim = \
+                collect_factor_and_basedimension(independent)
+            factor /= ifactor**count
+            dim /= idim**count
+        return factor, dim
+    elif isinstance(expr, Integral):
+        # Test that integration limits have the same units
+        collect_factor_and_basedimension(sum(expr.args[1]))
+        factor, dim = \
+            collect_factor_and_basedimension(expr.args[0]*expr.args[1][0])
+        return factor, dim    
+    elif isinstance(expr, Function):
+        fds = [collect_factor_and_basedimension(
+            arg) for arg in expr.args]
+        return (expr.func(*(f[0] for f in fds)),
+                expr.func(*(d[1] for d in fds)))
+    elif isinstance(expr, Dimension):
+        return 1, expr
+    else:
+        return expr, Dimension(1)
 
 
 class BaseVariable(Symbol):

--- a/essm/variables/_core.py
+++ b/essm/variables/_core.py
@@ -217,7 +217,7 @@ class Variable(object):
         elif isinstance(expr, Integral):
             # Test that integration limits have the same units
             Variable.collect_factor_and_basedimension(sum(expr.args[1]))
-            factor, dim = \
+            factor, dim = Variable.collect_factor_and_basedimension(
                 Variable.collect_factor_and_basedimension(expr.args[0] *
                                                           expr.args[1][0])
             return factor, dim

--- a/essm/variables/_core.py
+++ b/essm/variables/_core.py
@@ -215,15 +215,18 @@ class Variable(object):
                 dim /= idim**count
             return factor, dim
         elif isinstance(expr, Integral):
-            # Test that integration limits have the same units
-            Variable.collect_factor_and_basedimension(sum(expr.args[1]))
+            try:
+                Variable.collect_factor_and_basedimension(sum(expr.args[1]))
+            except ValueError:
+                raise ValueError(
+                    "Wrong dimensions of integration limits ({expr}).".format(
+                        expr=expr))
             factor, dim = \
                 Variable.collect_factor_and_basedimension(expr.args[0] *
                                                           expr.args[1][0])
             return factor, dim
         elif isinstance(expr, Piecewise):
-            factor, dim = \
-                Variable.collect_factor_and_basedimension(
+            factor, dim = Variable.collect_factor_and_basedimension(
                     sum([x[0] for x in expr.args]))
             return factor, dim
         elif isinstance(expr, Function):

--- a/essm/variables/_core.py
+++ b/essm/variables/_core.py
@@ -141,8 +141,7 @@ class Variable(object):
                                                 expr.args[1][0])
             return dim
         elif isinstance(expr, Piecewise):
-            dim = \
-                Variable.get_dimensional_expr(
+            dim = Variable.get_dimensional_expr(
                     sum([x[0] for x in expr.args]))
             return dim
         elif isinstance(expr, Function):

--- a/essm/variables/_core.py
+++ b/essm/variables/_core.py
@@ -135,6 +135,15 @@ class Variable(object):
             for independent, count in expr.variable_count:
                 dim /= Variable.get_dimensional_expr(independent) ** count
             return dim
+        elif isinstance(expr, Integral):
+            dim = Variable.get_dimensional_expr(expr.args[0] *
+                                                expr.args[1][0])
+            return dim
+        elif isinstance(expr, Piecewise):
+            dim = \
+                Variable.get_dimensional_expr(
+                    sum([x[0] for x in expr.args]))
+            return dim
         elif isinstance(expr, Function):
             args = [Variable.get_dimensional_expr(arg) for arg in expr.args]
             if all(i == 1 for i in args):
@@ -143,7 +152,7 @@ class Variable(object):
         elif isinstance(expr, Quantity):
             return expr.dimension.name
         elif isinstance(expr, BaseVariable):
-            return Quantity.get_dimensional_expr(expr.definition.unit)
+            return Variable.get_dimensional_expr(expr.definition.unit)
         return S.One
 
     @staticmethod

--- a/essm/variables/units.py
+++ b/essm/variables/units.py
@@ -139,12 +139,12 @@ def derive_baseunit(expr, name=None):
     for var1 in variables:
         q1 = Quantity('q_' + str(var1))
         q1.set_dimension(
-            Dimension(Quantity.get_dimensional_expr(
+            Dimension(Variable.get_dimensional_expr(
                 derive_baseunit(var1.definition.unit)))
         )
         q1.set_scale_factor(var1.definition.unit)
         expr = expr.xreplace({var1: q1})
-    dim = Dimension(Quantity.get_dimensional_expr(expr))
+    dim = Dimension(Variable.get_dimensional_expr(expr))
     return functools.reduce(
         operator.mul, (
             SI_BASE_DIMENSIONS[Symbol(d)] ** p

--- a/essm/variables/units.py
+++ b/essm/variables/units.py
@@ -135,6 +135,7 @@ def derive_baseunit(expr, name=None):
     from sympy.physics.units import Dimension
     from sympy.physics.units.dimensions import dimsys_SI
 
+    Variable.check_unit(expr)  # check for dimensional consistency
     variables = extract_variables(expr)
     for var1 in variables:
         q1 = Quantity('q_' + str(var1))

--- a/essm/variables/utils.py
+++ b/essm/variables/utils.py
@@ -30,7 +30,6 @@ from .units import markdown
 
 class ListTable(list):
     """Override list class to render HTML Table in Jupyter notbook.
-
     Takes a 2-dimensional list of the form ``[[1, 2, 3], [4, 5, 6]],``
     and renders an HTML Table in IPython Notebook.
 
@@ -43,6 +42,7 @@ class ListTable(list):
     >>> table.append(['1', '2'])
     >>> table
     [['Column1', 'Column2'], ['1', '2']]
+
     """
 
     def _repr_html_(self):

--- a/essm/variables/utils.py
+++ b/essm/variables/utils.py
@@ -30,13 +30,13 @@ from .units import markdown
 
 class ListTable(list):
     """Override list class to render HTML Table in Jupyter notbook.
+
     Takes a 2-dimensional list of the form ``[[1, 2, 3], [4, 5, 6]],``
     and renders an HTML Table in IPython Notebook.
 
     Source: https://calebmadrigal.com/display-list-as-table-in-ipython-notebook
 
     Example:
-
     >>> table = ListTable()
     >>> table.append(['Column1', 'Column2'])
     >>> table.append(['1', '2'])

--- a/setup.py
+++ b/setup.py
@@ -31,11 +31,11 @@ tests_require = [
     'check-manifest>=0.25',
     'coverage>=4.0',
     'isort>=4.2.2',
-    'pydocstyle>=1.0.0',
+    'pydocstyle>=1.0.0,<4.0.0',
     'pytest-cache>=1.0',
     'pytest-cov>=1.8.0',
     'pytest-pep8>=1.0.6',
-    'pytest>=2.8.0',
+    'pytest>=2.8.0,<5.0.0',
 ]
 
 extras_require = {

--- a/tests/test_equations.py
+++ b/tests/test_equations.py
@@ -135,6 +135,23 @@ def test_Integral():
             expr = Eq(demo_d, Integral(demo_v, (demo_t, 1, demo_t1)))
 
 
+def test_Piecewise():
+    """Test that dimensions of Piecewise functions are correct."""
+    from sympy import Piecewise
+
+    class valid_piecewise(Equation):
+        expr = Eq(demo_v, Piecewise((0, demo_t <= 0),
+                                    (demo_d / demo_t, demo_t <= demo_t1),
+                                    (0, True)))
+
+    with pytest.raises(ValueError):
+
+        class invalid_limits(Equation):
+            expr = Eq(demo_v, Piecewise((0, demo_t <= 0),
+                                        (demo_d * demo_t, demo_t <= demo_t1),
+                                        (0, True)))
+
+
 def test_exp():
     """Test that variables can be used in exponent of equation."""
     class eq_with_var_in_exp(Equation):

--- a/tests/test_equations.py
+++ b/tests/test_equations.py
@@ -45,6 +45,18 @@ class demo_d1(Variable):
     unit = meter
 
 
+class demo_t(Variable):
+    """Test variable."""
+
+    unit = second
+
+
+class demo_t1(Variable):
+    """Test variable."""
+
+    unit = second
+
+
 class demo_v(Variable):
     """Test variable."""
 
@@ -98,13 +110,29 @@ def test_units_sqrt():
         expr = Eq(demo_v, sqrt(demo_d * demo_d1) / demo_fall.definition.t)
 
 
-def test_integral():
+def test_integrate():
     """Test that variables can be used as integration symbols."""
     from sympy import integrate
 
     assert demo_g * demo_fall.definition.t ** S(3) / S(6) == integrate(
         demo_fall.rhs, demo_fall.definition.t
     )
+
+
+def test_Integral():
+    """Test that dimensions of Integrals are correct."""
+    from sympy import Integral
+
+    class valid_general_integral(Equation):
+        expr = Eq(demo_d, Integral(demo_v, demo_t))
+
+    class valid_specific_integral(Equation):
+        expr = Eq(demo_d, Integral(demo_v, (demo_t, 0, demo_t1)))
+
+    with pytest.raises(ValueError):
+
+        class invalid_limits(Equation):
+            expr = Eq(demo_d, Integral(demo_v, (demo_t, 1, demo_t1)))
 
 
 def test_exp():

--- a/tests/test_equations.py
+++ b/tests/test_equations.py
@@ -164,11 +164,6 @@ def test_piecewise():
                                         (demo_d * demo_t, demo_t <= demo_t1),
                                         (0, True)))
 
-        class invalid_limits(Equation):
-            expr = Eq(demo_v, Piecewise((0, demo_t <= 0),
-                                        (demo_d / demo_t, demo_t <= demo_v),
-                                        (0, True)))
-
 
 def test_exp():
     """Test that variables can be used in exponent of equation."""

--- a/tests/test_equations.py
+++ b/tests/test_equations.py
@@ -7,7 +7,8 @@ from essm import Eq
 from essm._generator import EquationWriter
 from essm.equations import Equation
 from essm.variables import Variable
-from essm.variables.units import joule, kelvin, kilogram, meter, mole, second
+from essm.variables.units import (joule, kelvin, kilogram, meter, mole, second,
+                                  derive_baseunit)
 from essm.variables.utils import (extract_variables, replace_defaults,
                                   replace_variables)
 from sympy import Derivative, exp, S, Symbol, solve, sqrt
@@ -96,6 +97,8 @@ def test_units_derivative():
 
         expr = Eq(demo_v, Derivative(demo_d, demo_fall.definition.t))
 
+    assert(derive_baseunit(valid_units.rhs) == meter / second)
+
     with pytest.raises(ValueError):
 
         class invalid_units_derivative(Equation):
@@ -129,6 +132,8 @@ def test_Integral():
     class valid_specific_integral(Equation):
         expr = Eq(demo_d, Integral(demo_v, (demo_t, 0, demo_t1)))
 
+    assert(derive_baseunit(valid_specific_integral.rhs) == meter)
+
     with pytest.raises(ValueError):
 
         class invalid_limits(Equation):
@@ -143,6 +148,8 @@ def test_Piecewise():
         expr = Eq(demo_v, Piecewise((0, demo_t <= 0),
                                     (demo_d / demo_t, demo_t <= demo_t1),
                                     (0, True)))
+
+    assert(derive_baseunit(valid_piecewise.rhs) == meter / second)
 
     with pytest.raises(ValueError):
 

--- a/tests/test_equations.py
+++ b/tests/test_equations.py
@@ -122,7 +122,7 @@ def test_integrate():
     )
 
 
-def test_Integral():
+def test_integral():
     """Test that dimensions of Integrals are correct."""
     from sympy import Integral
 
@@ -146,7 +146,7 @@ def test_log():
         expr = Eq(demo_d, demo_d1 * log(demo_t))
 
 
-def test_Piecewise():
+def test_piecewise():
     """Test that dimensions of Piecewise functions are correct."""
     from sympy import Piecewise
 

--- a/tests/test_equations.py
+++ b/tests/test_equations.py
@@ -146,7 +146,7 @@ def test_Piecewise():
 
     with pytest.raises(ValueError):
 
-        class invalid_limits(Equation):
+        class invalid_units1(Equation):
             expr = Eq(demo_v, Piecewise((0, demo_t <= 0),
                                         (demo_d * demo_t, demo_t <= demo_t1),
                                         (0, True)))

--- a/tests/test_equations.py
+++ b/tests/test_equations.py
@@ -97,7 +97,7 @@ def test_units_derivative():
 
         expr = Eq(demo_v, Derivative(demo_d, demo_fall.definition.t))
 
-    assert(derive_baseunit(valid_units.rhs) == meter / second)
+    assert derive_baseunit(valid_units.rhs) == meter / second
 
     with pytest.raises(ValueError):
 

--- a/tests/test_equations.py
+++ b/tests/test_equations.py
@@ -11,7 +11,7 @@ from essm.variables.units import (joule, kelvin, kilogram, meter, mole, second,
                                   derive_baseunit)
 from essm.variables.utils import (extract_variables, replace_defaults,
                                   replace_variables)
-from sympy import Derivative, exp, S, Symbol, solve, sqrt
+from sympy import Derivative, exp, log, S, Symbol, solve, sqrt
 from sympy.physics.units import Quantity, length, meter
 
 
@@ -138,6 +138,12 @@ def test_Integral():
 
         class invalid_limits(Equation):
             expr = Eq(demo_d, Integral(demo_v, (demo_t, 1, demo_t1)))
+
+
+def test_log():
+    """Test that log(unit) is dimensionless, as integrate(1/x, x) = log(x)."""
+    class valid_log(Equation):
+        expr = Eq(demo_d, demo_d1 * log(demo_t))
 
 
 def test_Piecewise():

--- a/tests/test_equations.py
+++ b/tests/test_equations.py
@@ -164,6 +164,11 @@ def test_piecewise():
                                         (demo_d * demo_t, demo_t <= demo_t1),
                                         (0, True)))
 
+        class invalid_limits1(Equation):
+            expr = Eq(demo_v, Piecewise((0, demo_t <= 0),
+                                        (demo_d / demo_t, demo_t <= demo_v),
+                                        (0, True)))
+
 
 def test_exp():
     """Test that variables can be used in exponent of equation."""

--- a/tests/test_equations.py
+++ b/tests/test_equations.py
@@ -164,6 +164,11 @@ def test_piecewise():
                                         (demo_d * demo_t, demo_t <= demo_t1),
                                         (0, True)))
 
+        class invalid_limits(Equation):
+            expr = Eq(demo_v, Piecewise((0, demo_t <= 0),
+                                        (demo_d / demo_t, demo_t <= demo_v),
+                                        (0, True)))
+
 
 def test_exp():
     """Test that variables can be used in exponent of equation."""


### PR DESCRIPTION
This solves #55 and adds support for `Integral` in `Equation`:
```python
    class valid_general_integral(Equation):
        expr = Eq(demo_d, Integral(demo_v, demo_t))
    class valid_specific_integral(Equation):
        expr = Eq(demo_d, Integral(demo_v, (demo_t, 0, demo_t1)))
```