### PR TITLE
Fix markdown

### DIFF
--- a/essm/variables/units.py
+++ b/essm/variables/units.py
@@ -100,7 +100,6 @@ def markdown(unit):
             if isinstance(arg, Quantity):
                 tuples.append((str(arg.abbrev), 1))
         tuples.sort(key=itemgetter(1), reverse=True)
-        tuples.sort(key=itemgetter(0))
         for item in tuples:
             if item[1] == 1:
                 str1 = str1 + ' ' + item[0]

--- a/essm/variables/utils.py
+++ b/essm/variables/utils.py
@@ -76,11 +76,16 @@ def generate_metadata_table(variables=None, include_header=True):
         symbol = '$' + variable.definition.latex_name + '$'
         name = str(variable)
         doc = variable.__doc__
-        defn = '$' + latex(Variable.__expressions__.get(variable, '')) + '$'
+        defn1 = Variable.__expressions__.get(variable, '')
+        if len(defn1) > 1:
+            defn = '$' + latex(defn1) + '$'
+        else:
+            defn = ''
         val = str(Variable.__defaults__.get(variable, '-'))
+        unit = markdown(variable.definition.unit)
 
         table.append(
-            (symbol, name, doc, defn, val, markdown(variable.definition.unit))
+            (symbol, name, doc, defn, val, unit)
         )
     return table
 

--- a/essm/variables/utils.py
+++ b/essm/variables/utils.py
@@ -56,20 +56,23 @@ class ListTable(list):
         return ''.join(html)
 
 
-def generate_metadata_table(variables=None, include_header=True):
+def generate_metadata_table(variables=None, include_header=True, cols=None):
     """Generate table of variables, default values and units.
 
     If variables not provided in list ``variables``, table will contain
     all variables in ``Variables.__registry__``.
+    It is possible to remove columns by providing a tuple with a subste of:
+    cols=('Symbol', 'Name', 'Description', 'Definition',
+                'Default value', 'Units')
     """
     from ._core import Variable
+    all_cols = ('Symbol', 'Name', 'Description', 'Definition',
+                'Default value', 'Units')
+    cols = cols or all_cols
     table = ListTable()
     variables = variables or Variable.__registry__.keys()
     if include_header:
-        table.append(
-            ('Symbol', 'Name', 'Description', 'Definition',
-             'Default value', 'Units')
-        )
+        table.append(cols)
 
     for variable in sorted(variables,
                            key=lambda x: x.definition.latex_name.lower()):
@@ -83,9 +86,16 @@ def generate_metadata_table(variables=None, include_header=True):
             defn = ''
         val = str(Variable.__defaults__.get(variable, '-'))
         unit = markdown(variable.definition.unit)
+        dict_col = {}
+        dict_col['Symbol'] = symbol
+        dict_col['Name'] = name
+        dict_col['Description'] = doc
+        dict_col['Definition'] = defn
+        dict_col['Default value'] = val
+        dict_col['Units'] = unit
 
         table.append(
-            (symbol, name, doc, defn, val, unit)
+            tuple(dict_col[item] for item in cols)
         )
     return table
 

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -165,6 +165,7 @@ def test_markdown():
     """Check markdown representation of units."""
     assert markdown(kilogram * meter / second ** 2) == 'kg m s$^{-2}$'
     assert markdown(meter / second) == 'm s$^{-1}$'
+    assert markdown(second / meter) == 's m$^{-1}$'
 
 
 def test_generate_metadata_table():

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -173,6 +173,6 @@ def test_generate_metadata_table():
     assert generate_metadata_table([E_l, lambda_E]) \
         == [('Symbol', 'Name', 'Description', 'Definition', 'Default value',
              'Units'),
-            ('$\\lambda_E$', 'lambda_E', 'Latent heat of evaporation.', '$$',
+            ('$\\lambda_E$', 'lambda_E', 'Latent heat of evaporation.', '',
             '2450000.0', 'J kg$^{-1}$'), ('$E_l$', 'E_l',
-            'Latent heat flux from leaf.', '$$', '-', 'J s$^{-1}$ m$^{-2}$')]
+            'Latent heat flux from leaf.', '', '-', 'J s$^{-1}$ m$^{-2}$')]

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -175,4 +175,4 @@ def test_generate_metadata_table():
              'Units'),
             ('$\\lambda_E$', 'lambda_E', 'Latent heat of evaporation.', '$$',
             '2450000.0', 'J kg$^{-1}$'), ('$E_l$', 'E_l',
-            'Latent heat flux from leaf.', '$$', '-', 'J m$^{-2}$ s$^{-1}$')]
+            'Latent heat flux from leaf.', '$$', '-', 'J s$^{-1}$ m$^{-2}$')]


### PR DESCRIPTION
This PR orders units for latex output more sensibly.

Current behaviour:
```python
markdown(second / meter)
```
> 'm$^{-1}$ s'

New result would be:

> 's m$^{-1}$'
