### PR TITLE
Fix generate_metadata_table and add test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ git:
   depth: false
 
 python:
-  - '2.7'
   - '3.6'
 
 sudo: true

--- a/essm/variables/utils.py
+++ b/essm/variables/utils.py
@@ -80,7 +80,7 @@ def generate_metadata_table(variables=None, include_header=True, cols=None):
         name = str(variable)
         doc = variable.__doc__
         defn1 = Variable.__expressions__.get(variable, '')
-        if len(defn1) > 1:
+        if len(str(defn1)) > 1:
             defn = '$' + latex(defn1) + '$'
         else:
             defn = ''

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -170,9 +170,12 @@ def test_markdown():
 
 def test_generate_metadata_table():
     """Check display of table of units."""
-    assert generate_metadata_table([E_l, lambda_E]) \
+    assert generate_metadata_table([demo_expression_variable, E_l, lambda_E]) \
         == [('Symbol', 'Name', 'Description', 'Definition', 'Default value',
              'Units'),
             ('$\\lambda_E$', 'lambda_E', 'Latent heat of evaporation.', '',
-            '2450000.0', 'J kg$^{-1}$'), ('$E_l$', 'E_l',
+            '2450000.0', 'J kg$^{-1}$'),
+            ('$demo_expression_variable$', 'demo_expression_variable',
+            'Test expression variable.', '$2 demo_variable$', '-', 'm'),
+            ('$E_l$', 'E_l',
             'Latent heat flux from leaf.', '', '-', 'J s$^{-1}$ m$^{-2}$')]


### PR DESCRIPTION
The printing of a table of variables using `generate_metadata_table` currently fails if variables include expressions. This PR fixes it.