### PR TITLE
WIP: Allow use of symbolic function in equation and add test

### DIFF
--- a/essm/variables/_core.py
+++ b/essm/variables/_core.py
@@ -232,10 +232,10 @@ class Variable(object):
         elif isinstance(expr, Function):
             fds = {Variable.collect_factor_and_basedimension(
                 arg)[1] for arg in expr.args}
-            if fds != {Dimension(1)}:
-                raise ValueError(
-                    'Arguments in function are not dimensionless, '
-                    'but have dimensions of {0}'.format(fds))
+            # if fds != {Dimension(1)}:
+            #     raise ValueError(
+            #         'Arguments in function are not dimensionless, '
+            #         'but have dimensions of {0}'.format(fds))
             return expr, Dimension(1)
         elif isinstance(expr, Dimension):
             return 1, expr

--- a/tests/test_equations.py
+++ b/tests/test_equations.py
@@ -11,7 +11,7 @@ from essm.variables.units import (joule, kelvin, kilogram, meter, mole, second,
                                   derive_baseunit)
 from essm.variables.utils import (extract_variables, replace_defaults,
                                   replace_variables)
-from sympy import cos, Derivative, exp, log, S, Symbol, solve, sqrt
+from sympy import cos, Derivative, exp, Function, log, S, Symbol, solve, sqrt
 from sympy.physics.units import Quantity, length, meter
 
 
@@ -286,6 +286,15 @@ def test_check_unit():
 
     assert Variable.check_unit(1 - exp(var_joule / var_joule_base)) == \
         1 - exp(var_joule/var_joule_base)
+
+
+def test_check_unit_function():
+    """
+    Make sure that check_unit works with symbolic functions"""
+
+    f = Function('f')(demo_t)
+    assert Variable.check_unit(Derivative(f, demo_t)) == \
+        Derivative(f, demo_t)
 
 
 def test_double_registration():


### PR DESCRIPTION
In the current version, it is not possible to use symbolic functions in Equation(), e.g.:
```python
from sympy import Derivative, Eq, Function, symbols
from essm.variables import Variable
from essm.equations import Equation
from essm.variables.units import meter, second

class v(Variable):
    """Velocity"""
    unit = meter / second

class d(Variable):
    """Distance"""
    unit = meter
    
class t(Variable):
    """Time"""
    unit = second

dt = Function(d)(t)    
class eq_v(Equation):
    """Average velocity as a function of time"""
    expr = Eq(v, Derivative(dt, t))
```
> ValueError: Arguments in function are not dimensionless, but have dimensions of {Dimension(time)}

This PR disables the requirement that arguments in functions must be dimensionless.